### PR TITLE
Added CachePath to CefUtil

### DIFF
--- a/common/src/main/java/com/cinemamod/mcef/CefUtil.java
+++ b/common/src/main/java/com/cinemamod/mcef/CefUtil.java
@@ -100,7 +100,7 @@ final class CefUtil {
 
         CefSettings cefSettings = new CefSettings();
         cefSettings.windowless_rendering_enabled = true;
-        cefSettings.cache_path = CACHE_PATH.toString();
+        if (settings.isUsingCache()) cefSettings.cache_path = CACHE_PATH.toString();
         cefSettings.background_color = cefSettings.new ColorType(0, 255, 255, 255);
         // Set the user agent if there's one defined in MCEFSettings
         if (!Objects.equals(settings.getUserAgent(), "null")) {

--- a/common/src/main/java/com/cinemamod/mcef/CefUtil.java
+++ b/common/src/main/java/com/cinemamod/mcef/CefUtil.java
@@ -47,9 +47,8 @@ final class CefUtil {
 
     private static final Path CACHE_PATH = Minecraft.getInstance().gameDirectory
             .toPath()
-            .resolve("config")
-            .resolve("mcef")
-            .resolve("cache");
+            .resolve("mods")
+            .resolve("mcef-cache");
 
     private static void setUnixExecutable(File file) {
         Set<PosixFilePermission> perms = new HashSet<>();

--- a/common/src/main/java/com/cinemamod/mcef/CefUtil.java
+++ b/common/src/main/java/com/cinemamod/mcef/CefUtil.java
@@ -20,6 +20,7 @@
 
 package com.cinemamod.mcef;
 
+import net.minecraft.client.Minecraft;
 import org.cef.CefApp;
 import org.cef.CefClient;
 import org.cef.CefSettings;
@@ -27,6 +28,7 @@ import org.cef.CefSettings;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.Objects;
@@ -42,6 +44,12 @@ final class CefUtil {
     private static boolean init;
     private static CefApp cefAppInstance;
     private static CefClient cefClientInstance;
+
+    private static final Path CACHE_PATH = Minecraft.getInstance().gameDirectory
+            .toPath()
+            .resolve("config")
+            .resolve("mcef")
+            .resolve("cache");
 
     private static void setUnixExecutable(File file) {
         Set<PosixFilePermission> perms = new HashSet<>();
@@ -93,6 +101,7 @@ final class CefUtil {
 
         CefSettings cefSettings = new CefSettings();
         cefSettings.windowless_rendering_enabled = true;
+        cefSettings.cache_path = CACHE_PATH.toString();
         cefSettings.background_color = cefSettings.new ColorType(0, 255, 255, 255);
         // Set the user agent if there's one defined in MCEFSettings
         if (!Objects.equals(settings.getUserAgent(), "null")) {

--- a/common/src/main/java/com/cinemamod/mcef/MCEFSettings.java
+++ b/common/src/main/java/com/cinemamod/mcef/MCEFSettings.java
@@ -41,11 +41,13 @@ public class MCEFSettings {
     private boolean skipDownload;
     private String downloadMirror;
     private String userAgent;
+    private boolean useCache;
 
     public MCEFSettings() {
         skipDownload = false;
         downloadMirror = "https://mcef-download.cinemamod.com";
         userAgent = null;
+        useCache = true;
     }
 
     public boolean isSkipDownload() {
@@ -75,6 +77,10 @@ public class MCEFSettings {
         saveAsync();
     }
 
+    public boolean isUsingCache() {
+        return useCache;
+    }
+
     public void saveAsync() {
         CompletableFuture.runAsync(() -> {
             try {
@@ -98,6 +104,7 @@ public class MCEFSettings {
         properties.setProperty("skip-download", String.valueOf(skipDownload));
         properties.setProperty("download-mirror", String.valueOf(downloadMirror));
         properties.setProperty("user-agent", String.valueOf(userAgent));
+        properties.setProperty("use-cache", String.valueOf(useCache));
 
         try (FileOutputStream output = new FileOutputStream(file)) {
             properties.store(output, null);
@@ -121,6 +128,7 @@ public class MCEFSettings {
             skipDownload = Boolean.parseBoolean(properties.getProperty("skip-download"));
             downloadMirror = properties.getProperty("download-mirror");
             userAgent = properties.getProperty("user-agent");
+            useCache = Boolean.parseBoolean(properties.getProperty("use-cache"));
         } catch (Exception e) {
             // Delete and re-create the file if there was a parsing error
             if (deleteRetries++ > 20)


### PR DESCRIPTION
Enabled LocalStorage/Cookies in CefUtil by adding a cache path for CEF in the CefSettings. 
The directory is called 'cache' and is located in the config/mcef directory.