### PR TITLE
make fabric version work on 1.21.1

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   ],
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",
-    "minecraft": "1.21",
+    "minecraft": ["1.21", "1.21.1"],
     "java": ">=${java_version}"
   },
   "breaks": {


### PR DESCRIPTION
tested this with both fabric and neoforge with no issues

Neoforge doesn't seem to need any change at all in its neoforge.mods.toml

mcef can work with 1.21 and 1.21.1 simultaneously as there was little that was changed in 1.21.1

closes #94, closes Blobanium/MCBrowser#14